### PR TITLE
chakrashim: fix Object::SetInternalField …

### DIFF
--- a/deps/chakrashim/src/v8chakra.h
+++ b/deps/chakrashim/src/v8chakra.h
@@ -32,7 +32,7 @@ struct ObjectData {
  public:
   struct FieldValue {
    public:
-    FieldValue() : value(nullptr) {}
+    FieldValue() : value(nullptr), isRefValue(false){}
     ~FieldValue() { Reset(); }
 
     void SetRef(JsValueRef ref);
@@ -43,10 +43,9 @@ struct ObjectData {
     void* GetPointer() const;
 
    private:
-    static const UINT_PTR kValueRefTag = 1;
-    static const UINT_PTR kValueRefMask = ~kValueRefTag;
     void Reset();
 
+    bool isRefValue;
     void* value;
   };
 

--- a/deps/chakrashim/src/v8objecttemplate.cc
+++ b/deps/chakrashim/src/v8objecttemplate.cc
@@ -94,23 +94,25 @@ void ObjectData::FieldValue::SetRef(JsValueRef ref) {
   }
 
   value = reinterpret_cast<void*>(
-    reinterpret_cast<UINT_PTR>(ref) | kValueRefTag);
+    reinterpret_cast<UINT_PTR>(ref));
+  isRefValue = true;
   CHAKRA_ASSERT(GetRef() == ref);
 }
 
 JsValueRef ObjectData::FieldValue::GetRef() const {
   CHAKRA_ASSERT(IsRef() || !value);
   return reinterpret_cast<JsValueRef>(
-    reinterpret_cast<UINT_PTR>(value) & kValueRefMask);
+    reinterpret_cast<UINT_PTR>(value));
 }
 
 bool ObjectData::FieldValue::IsRef() const {
-  return (reinterpret_cast<UINT_PTR>(value) & kValueRefTag) != 0;
+  return isRefValue;
 }
 
 void ObjectData::FieldValue::SetPointer(void* ptr) {
   Reset();
   value = ptr;
+  isRefValue = false;
   CHAKRA_ASSERT(GetPointer() == ptr);
 }
 
@@ -123,6 +125,7 @@ void ObjectData::FieldValue::Reset() {
   if (IsRef()) {
     JsRelease(GetRef(), nullptr);
   }
+  isRefValue = false;
   value = nullptr;
 }
 


### PR DESCRIPTION
When use SetInternalField with Interger will assert:

// assert this
object->SetInternalField(0, v8::Integer::New(env->isolate(), 6));
object->GetInternalField(0)->IsInt32();

Becasue ObjectData::FieldValue will change ref pointer with a mask , and then will not revert to a normal int value.

Soloution:
Add a bool flag to ObjectData::FieldValue to demined a FieldValue is JsValueRef or not.
